### PR TITLE
Protegendo as chaves de acesso

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,0 @@
-consumer_key="CyDRrymFgLSke7THscHb7naMK"
-consumer_secret="klhXLmMYaC47b6wqEjwe7JGpXIRjR38JeGOE6b5ZjUq71qbohw"
-access_token="1162495874192293890-gfJ49ZgAA0nQZPMQFYpKhWZlSPtDNW"
-access_token_secret="HJA4v18oW8d5iiNYyfXNKreyZmPie1akSLXEwau0fDp2a"

--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,4 @@
+consumer_key=""
+consumer_secret=""
+access_token=""
+access_token_secret=""

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.vscode
 /__pycache__
+.env


### PR DESCRIPTION
O arquivo .env é geralmente mantidos fora do controle de versão, uma vez que podem conter chaves de API sensíveis e senhas, em outras palavras caso você tenha uma equipe desenvolvendo o projeto esse arquivo não deve ser enviado ao Git